### PR TITLE
Implement provisioning for google workspace v2

### DIFF
--- a/pkg/connector/group.go
+++ b/pkg/connector/group.go
@@ -159,7 +159,7 @@ func (o *groupResourceType) Grant(ctx context.Context, principal *v2.Resource, e
 		return nil, nil, errors.New("google-workspace-v2: user principal is required")
 	}
 
-	r := o.groupService.Members.Insert(o.customerId, &admin.Member{Id: principal.GetId().GetResource()})
+	r := o.groupService.Members.Insert(entitlement.Resource.Id.Resource, &admin.Member{Id: principal.GetId().GetResource()})
 	assignment, err := r.Context(ctx).Do()
 	if err != nil {
 		return nil, nil, fmt.Errorf("google-workspace-v2: failed to insert group member: %w", err)

--- a/pkg/connector/group.go
+++ b/pkg/connector/group.go
@@ -123,10 +123,8 @@ func (o *groupResourceType) Grants(ctx context.Context, resource *v2.Resource, p
 		if err != nil {
 			return nil, "", nil, err
 		}
-		grant := sdkGrant.NewGrant(resource, groupMemberEntitlement, gmID)
-		annos := annotations.Annotations(grant.Annotations)
-		annos.Update(v1Identifier)
-		grant.Annotations = annos
+		grant := sdkGrant.NewGrant(resource, groupMemberEntitlement, gmID, sdkGrant.WithAnnotation(v1Identifier))
+		grant.Id = member.Id
 		rv = append(rv, grant)
 	}
 

--- a/pkg/connector/role.go
+++ b/pkg/connector/role.go
@@ -160,7 +160,11 @@ func (o *roleResourceType) Grant(ctx context.Context, principal *v2.Resource, en
 	if err != nil {
 		return nil, nil, fmt.Errorf("google-workspace-v2: failed to convert roleId to string: %w", err)
 	}
-	r := o.roleService.RoleAssignments.Insert(o.customerId, &admin.RoleAssignment{AssignedTo: principal.GetId().GetResource(), RoleId: tempRoleId})
+	r := o.roleService.RoleAssignments.Insert(o.customerId, &admin.RoleAssignment{
+		AssignedTo: principal.GetId().GetResource(),
+		RoleId:     tempRoleId,
+		ScopeType:  "CUSTOMER",
+	})
 	assignment, err := r.Context(ctx).Do()
 	if err != nil {
 		return nil, nil, fmt.Errorf("google-workspace-v2: failed to insert role member: %w", err)

--- a/pkg/connector/role.go
+++ b/pkg/connector/role.go
@@ -123,10 +123,8 @@ func (o *roleResourceType) Grants(ctx context.Context, resource *v2.Resource, pt
 		if err != nil {
 			return nil, "", nil, err
 		}
-		grant := sdkGrant.NewGrant(resource, roleMemberEntitlement, uID)
-		annos := annotations.Annotations(grant.Annotations)
-		annos.Update(v1Identifier)
-		grant.Annotations = annos
+		grant := sdkGrant.NewGrant(resource, roleMemberEntitlement, uID, sdkGrant.WithAnnotation(v1Identifier))
+		grant.Id = tempRoleAssignmentId
 		rv = append(rv, grant)
 	}
 


### PR DESCRIPTION
A conscience decision was made to change the IDs for listing roles and groups here to be the IDs of the relationships (memberships or role assignments) of the bindings themselves in order to support provisioning goals. This is expected to cause churn for existing grants, but that should be ok? It won't churn entitlements.