### PR TITLE
Fixes grants for roles and groups, and also fixes revokes for groups

### DIFF
--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -176,19 +176,25 @@ func (c *GoogleWorkspace) Asset(ctx context.Context, asset *v2.AssetRef) (string
 
 func (c *GoogleWorkspace) ResourceSyncers(ctx context.Context) []connectorbuilder.ResourceSyncer {
 	rs := []connectorbuilder.ResourceSyncer{}
+	// We don't care about the error here, as we handle the case where the service is nil in the syncer
+	roleProvisioningService, _ := c.getDirectoryService(ctx, directoryAdmin.AdminDirectoryRolemanagementScope)
 	roleService, err := c.getDirectoryService(ctx, directoryAdmin.AdminDirectoryRolemanagementReadonlyScope)
 	if err == nil {
-		rs = append(rs, roleBuilder(roleService, c.customerID))
+		rs = append(rs, roleBuilder(roleService, c.customerID, roleProvisioningService))
 	}
+
 	userService, err := c.getDirectoryService(ctx, directoryAdmin.AdminDirectoryUserReadonlyScope)
 	if err == nil {
 		rs = append(rs, userBuilder(userService, c.customerID, c.domain))
 	}
+
+	// We don't care about the error here, as we handle the case where the service is nil in the syncer
+	groupProvisioningService, _ := c.getDirectoryService(ctx, directoryAdmin.AdminDirectoryGroupMemberScope)
 	groupService, err := c.getDirectoryService(ctx, directoryAdmin.AdminDirectoryGroupReadonlyScope)
 	if err == nil {
 		groupMemberService, err := c.getDirectoryService(ctx, directoryAdmin.AdminDirectoryGroupMemberReadonlyScope)
 		if err == nil {
-			rs = append(rs, groupBuilder(groupService, c.customerID, c.domain, groupMemberService))
+			rs = append(rs, groupBuilder(groupService, c.customerID, c.domain, groupMemberService, groupProvisioningService))
 		}
 	}
 	return rs

--- a/pkg/connector/user.go
+++ b/pkg/connector/user.go
@@ -15,10 +15,11 @@ import (
 )
 
 type userResourceType struct {
-	resourceType *v2.ResourceType
-	userService  *admin.Service
-	customerId   string
-	domain       string
+	resourceType            *v2.ResourceType
+	userService             *admin.Service
+	userProvisioningService *admin.Service
+	customerId              string
+	domain                  string
 }
 
 func (o *userResourceType) ResourceType(_ context.Context) *v2.ResourceType {

--- a/pkg/connector/user.go
+++ b/pkg/connector/user.go
@@ -15,11 +15,10 @@ import (
 )
 
 type userResourceType struct {
-	resourceType            *v2.ResourceType
-	userService             *admin.Service
-	userProvisioningService *admin.Service
-	customerId              string
-	domain                  string
+	resourceType *v2.ResourceType
+	userService  *admin.Service
+	customerId   string
+	domain       string
 }
 
 func (o *userResourceType) ResourceType(_ context.Context) *v2.ResourceType {


### PR DESCRIPTION
This PR is a work in progress, as revokes for roles seems to still fail. 

```
{"level":"error","ts":1726880170.599183,"caller":"ugrpc/logging.go:35","msg":"finished unary call with code Unknown","grpc.start_time":"2024-09-20T17:56:10-07:00","grpc.service":"c1.connector.v2.GrantManagerService","grpc.method":"Revoke","peer.address":"127.0.0.1:65088","error":"error: revoke failed: google-workspace-v2: failed to remove role member: googleapi: Error 403: The operation is not allowed, forbidden","grpc.code":"Unknown","grpc.time_ms":187.451}
```