### PR TITLE
Add logging for list groups

### DIFF
--- a/pkg/connector/group.go
+++ b/pkg/connector/group.go
@@ -69,13 +69,15 @@ func (o *groupResourceType) List(ctx context.Context, resourceId *v2.ResourceId,
 	if err != nil {
 		return nil, "", nil, fmt.Errorf("google-workspace: cannot get groups: %w", err)
 	}
+
+	serverResponse := groups.ServerResponse
 	if len(groups.Groups) == 0 {
-		l.Warn("no groups found", zap.Int("status", groups.ServerResponse.HTTPStatusCode),
-			zap.Any("header", groups.ServerResponse.Header), zap.String("req", bag.PageToken()))
+		l.Warn("no groups found", zap.Int("status", serverResponse.HTTPStatusCode),
+			zap.Any("header", serverResponse.Header), zap.String("req", bag.PageToken()))
 	} else {
 		l.Debug("groups found", zap.Int("count", len(groups.Groups)),
-			zap.Int("status", groups.ServerResponse.HTTPStatusCode),
-			zap.Any("header", groups.ServerResponse.Header), zap.String("req", bag.PageToken()))
+			zap.Int("status", serverResponse.HTTPStatusCode),
+			zap.Any("header", serverResponse.Header), zap.String("req", bag.PageToken()))
 	}
 
 	rv := make([]*v2.Resource, 0, len(groups.Groups))


### PR DESCRIPTION
For troubleshooting INC-409

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved post-fetch logging for group retrieval: logs a warning when no groups are returned and a debug entry with the group count when groups are found, including request context for troubleshooting.
  * No changes to functionality, API responses, or error handling; no impact for end-users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->