### PR TITLE
expose user id in profile for actions

### DIFF
--- a/pkg/connector/user.go
+++ b/pkg/connector/user.go
@@ -135,6 +135,7 @@ func userProfile(ctx context.Context, user *admin.User) map[string]interface{} {
 		profile["manager_email"] = extractManagerEmail(user)
 	}
 
+	profile["user_id"] = user.Id
 	profile["org_unit_path"] = user.OrgUnitPath
 
 	primaryOrg := extractPrimaryOrganizations(user)


### PR DESCRIPTION
Expose user.id in profile so it can be used from ctx.trigger when invoking an action

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * User ID is now included in user profile information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->