### PR TITLE
Add employee_type to user profile from organization description

### DIFF
--- a/pkg/connector/user.go
+++ b/pkg/connector/user.go
@@ -145,6 +145,7 @@ func userProfile(ctx context.Context, user *admin.User) map[string]interface{} {
 		profile["title"] = primaryOrg.Title
 		profile["location"] = primaryOrg.Location
 		profile["cost_center"] = primaryOrg.CostCenter
+		profile["description"] = primaryOrg.Description
 	}
 
 	return profile


### PR DESCRIPTION
## Summary
- Adds `employee_type` to the user profile, populated from the organization's `description` field
- In the Google Workspace Admin UI under Employee Information, there is a "Type of employee" field that maps to the API's `description` field
- This field has been missing but can be critical to workflows for understanding how users and access for those users should be evaluated

## Test plan
- [ ] Sync a Google Workspace instance with users that have "Type of employee" populated
- [ ] Verify the `employee_type` field appears in the user profile

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * User profiles now surface the primary organization’s description when available.
  * User profiles continue to include employee-type information sourced from the primary organization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->