### PR TITLE
Remove image frame from group settings instructions

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -85,10 +85,6 @@ Click **Enable**.
 
 <Step>
 **Optional.** If you want to use the group settings connector action, you must also search for, select, and enable the **Groups Settings API**.
-
-   <Frame>
-   <img src="/images/product/assets/google-19.png" alt="" />
-   </Frame>
 </Step>
 <Step>
 You must also search for, select, and enable the **Cloud Identity API** (used for resolving SAML app IDs to stable identifiers).


### PR DESCRIPTION
Removed image reference from doc, not sure if I missed this one or if it got reverted.