### PR TITLE
docs: fix connector doc regressions

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -254,7 +254,7 @@ Click **Manage Domains**. Locate and copy the domain labeled as the **Primary Do
 </Step>
 </Steps>
 
-**That's it!** Next, move on to the connector configuration instructions. 
+**Done.** Next, move on to the connector configuration instructions. 
 
 ## Configure the Google Workspace connector
 
@@ -315,7 +315,7 @@ The connector's label changes to **Syncing**, followed by **Connected**. You can
 </Step>
 </Steps>
 
-**That's it!** Your Google Workspace connector is now pulling access data into C1.
+**Done.** Your Google Workspace connector is now pulling access data into C1.
 </Tab>
 
 <Tab title="Self-hosted">
@@ -435,7 +435,7 @@ Check that the connector data uploaded correctly. In C1, click **Apps**. On the 
 </Step>
 </Steps>
 
-**That's it!** Your Google Workspace connector is now pulling access data into C1.
+**Done.** Your Google Workspace connector is now pulling access data into C1.
 </Tab>
 </Tabs>
 


### PR DESCRIPTION
## Summary

Fixes an issue in `docs/connector.mdx` caught during a sync to the ConductorOne docs site:

- Restore `**Done.**` closing phrase (replaces `**That's it!**`)

This correction prevents the sync bot from reintroducing the regression on future runs.