### PR TITLE
fix: recover panics in the fetchUserTokens worker goroutine

### DIFF
--- a/pkg/connector/app_login.go
+++ b/pkg/connector/app_login.go
@@ -308,6 +308,15 @@ func fetchUserTokens(ctx context.Context, sem *semaphore.Weighted, client *gwcli
 		go func(idx int, user *admin.User) {
 			defer wg.Done()
 			defer sem.Release(1)
+			defer func() {
+				if r := recover(); r != nil {
+					ctxzap.Extract(ctx).Error("google-workspace-connector: fetchUserTokens goroutine recovered from panic",
+						zap.String("user_id", user.Id),
+						zap.Any("panic", r),
+						zap.Stack("stack"),
+					)
+				}
+			}()
 
 			tokenResp, err := client.ListTokens(ctx, user.Id)
 			if err != nil {


### PR DESCRIPTION
\`fetchUserTokens\` spawns a bounded worker pool that fans out one goroutine per user, each calling \`client.ListTokens\` and downstream Google SDK code. None of the workers had a \`defer recover()\`, so a panic in any user's token-fetch path crashed the entire connector process rather than just failing that user's sync.

Added a \`defer recover()\` at the top of the worker that logs the panic + stack via the existing zap logger and lets the goroutine exit; the user's slot in \`results\` stays at its zero value (\`userAppsResult{}\`) so the outer loop treats the user as having no enumerable apps. The semaphore \`Release\` + \`wg.Done\` defers fire normally so the pool unwinds cleanly.

How found: occult-go-analysis baton pool scan (2026-05-20), detector \`goroutine_without_recover\`.