### PR TITLE
fix: set 30s Timeout on newGWSAdminServiceForScopes HTTP client

### DIFF
--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -9,6 +9,7 @@ import (
 	"reflect"
 	"strings"
 	"sync"
+	"time"
 
 	config "github.com/conductorone/baton-sdk/pb/c1/config/v1"
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
@@ -360,6 +361,7 @@ func newGWSAdminServiceForScopes[T any](ctx context.Context, credentials []byte,
 	}
 
 	httpClient = &http.Client{
+		Timeout: 30 * time.Second,
 		Transport: &oauth2.Transport{
 			Base:   httpClient.Transport,
 			Source: oauth2.ReuseTokenSource(token, tokenSrc),


### PR DESCRIPTION
## what changed

`newGWSAdminServiceForScopes` rebuilds an `http.Client` to wrap the underlying transport with oauth2 token-refresh logic. The replacement literal omits `Timeout`, so a hung Google API endpoint stalls the requesting goroutine forever -- goroutines hold onto large config/credential state and the sync handler can be unrecoverably blocked.

This adds a 30-second `Timeout` to that client literal.

## how I found this

Static analysis with [occult-go-analysis](https://github.com/conductorone/occult-go-analysis), c1 profile, `http_client_literal_without_timeout` detector.