### PR TITLE
docs: update Docker image registry from GHCR to ECR Public

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -414,7 +414,7 @@ spec:
     spec:
       containers:
       - name: baton-google-workspace
-        image: ghcr.io/conductorone/baton-google-workspace:latest
+        image: public.ecr.aws/conductorone/baton-google-workspace:latest
         imagePullPolicy: IfNotPresent
         env:
         - name: BATON_HOST_ID
@@ -480,4 +480,3 @@ Re-add the relevant scopes:
    ```
 </Step>
 </Steps>
-


### PR DESCRIPTION
## Summary

Connector images are now published exclusively to ECR Public (`public.ecr.aws/conductorone/`). This PR updates `docs/connector.mdx` accordingly.

**Changes made:**
- Updates Docker image reference from `ghcr.io/conductorone/` to `public.ecr.aws/conductorone/`
- Adds `### Resources` section (download center + GitHub repo links) if missing from the self-hosted setup instructions

_This PR was generated automatically._