### PR TITLE
docs: expand admin.directory.user scope purpose

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -215,7 +215,7 @@ Click **Add new** and fill out the form:
         Purpose: (Write) To manage role assignments (grant or revoke roles).
 
       - Scope:   https://www.googleapis.com/auth/admin.directory.user <br/>
-        Purpose: (Write) To provision/deprovision accounts.
+        Purpose: (Write) To provision/deprovision accounts, update user profiles and custom-schema values, and promote/demote super administrators.
 
       - Scope:   https://www.googleapis.com/auth/admin.reports.audit.readonly <br/>
         Purpose: To sync usage events and admin events (used in conjunction with continuous sync).


### PR DESCRIPTION
## Summary

Mirrors the **accurate** portion of [ConductorOne/docs#400](https://github.com/ConductorOne/docs/pull/400) into the source-of-truth connector docs (`docs/connector.mdx`).

Updates the `admin.directory.user` write scope purpose from:

> Purpose: (Write) To provision/deprovision accounts.

to:

> Purpose: (Write) To provision/deprovision accounts, update user profiles and custom-schema values, and promote/demote super administrators.

This matches the connector's user actions (`update_user_profile`, `update_user`, `make_admin` in `pkg/connector/user_actions.go`) and the internal `docs/docs-info.md` scope table.

## Not included from docs#400

- **Actions table additions** — already present in `docs/connector.mdx` (`update_user_profile`, `update_user`, `make_admin`).
- **Custom-schema null-delete `<Warning>`** — intentionally omitted. The claim in docs#400 (that `null` is silently ignored and you must use an empty string/sentinel) contradicts Google's Directory API documentation, which states you delete a custom field by setting it to `null` explicitly. The connector passes `custom_schemas` verbatim, so `null` reaches Google and deletes the field. Flagged separately on docs#400.

🤖 Generated with [Claude Code](https://claude.com/claude-code)