### PR TITLE
docs: add capabilities summary for group delete, continuous sync, and targeted sync

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -21,7 +21,7 @@ sidebarTitle: "Google Workspace"
 
 The Google Workspace connector supports [automatic account provisioning and deprovisioning](/product/admin/account-provisioning).
 
-The connector also supports group creation and deletion, [continuous sync](/baton/faq#syncing), and targeted sync.
+The connector also supports group creation (via the `create_group` connector action) and deletion, [continuous sync](/baton/faq#syncing), and targeted sync for accounts, groups, and roles.
 
 ### Connector actions
 

--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -21,6 +21,8 @@ sidebarTitle: "Google Workspace"
 
 The Google Workspace connector supports [automatic account provisioning and deprovisioning](/product/admin/account-provisioning).
 
+The connector also supports group creation and deletion, [continuous sync](/baton/faq#syncing), and targeted sync.
+
 ### Connector actions
 
 Connector actions are custom capabilities that extend C1 automations with app-specific operations. You can use connector actions in the [Perform connector action](/product/admin/automations-steps-reference#perform-connector-action) automation step.


### PR DESCRIPTION
## Summary

Follow-up to [ConductorOne/docs#441](https://github.com/ConductorOne/docs/pull/441). Now that connector doc updates go through `docs/connector.mdx` (the source of truth synced to the public site) instead of direct PRs to the `docs` repo, this adds the one remaining accuracy gap that wasn't already covered by main.

- **Adds a capabilities summary sentence** (group creation/deletion, continuous sync, targeted sync) that was present in the external docs PR but missing from this repo's copy of the page.

**Note:** this PR originally also included a broadened `employee_id` fallback description, but that was independently fixed by #127 (merged to main after this branch was created) with a more complete version that also documents the `manager_email` skip-and-report behavior change. Rebased to drop the now-redundant part and keep only the capabilities addition.

### Verification

- Capabilities: `baton_capabilities.json` (`CAPABILITY_TARGETED_SYNC`, `CAPABILITY_SERVICE_MODE_TARGETED_SYNC`, `CAPABILITY_EVENT_FEED_V2`, `CAPABILITY_RESOURCE_DELETE` on group)
- Group deletion: `pkg/connector/group.go:269`
- FAQ anchor: confirmed `/baton/faq#syncing` matches the `### Syncing` heading (the `#what-is-syncing` anchor used in the original external docs PR did not match any heading)

## Test plan

- [ ] Docs-only change; no code affected. Render/preview `docs/connector.mdx` to confirm formatting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)